### PR TITLE
refactor planning with recursive chain search

### DIFF
--- a/STRATEGIES.md
+++ b/STRATEGIES.md
@@ -26,12 +26,12 @@ This file tracks the Team strategies we experimented with, plus rough results (a
    - Require margins on first hops; forbid new vacancy much closer to Mouse.
    - Avg typically ≈ 1–3s with current geometry.
 
-7. Cordon Mode (v1)
-   - When Mouse is within R of vacancy, dispatch K defenders to surround vacancy by occupying K nearest seats to that chair, plus the vacancy itself.
-   - Configurable via `tuning.cordonR`, `tuning.cordonK`.
-   - In progress; see `simulation.mjs`.
+7. Cordon Mode (reservations)
+   - When the Mouse is within `reservedRadius` of a vacancy, reserve that chair plus its `cordonK` nearest chairs for `cordonHold` seconds.
+   - Configurable via `tuning.reservedRadius`, `tuning.cordonK`, `tuning.cordonHold`.
+   - Implemented in `simulation.mjs`.
 
 Next candidates:
-- Persistent Cordon (reserve K seats for a hold duration, reassign as needed).
+
 - Geometry-aware no-closer on every hop & guard seats.
-- Speed/geometry co-tuning (N, r, teamSpeed/mouseSpeed ratios). 
+- Speed/geometry co-tuning (N, r, teamSpeed/mouseSpeed ratios).

--- a/search.mjs
+++ b/search.mjs
@@ -1,52 +1,58 @@
 import { createSimulation } from './simulation.mjs'
 
-function runOnce(tuning, seed){
+function runOnce(tuning, seed) {
   const sim = createSimulation({ seed, tuning })
   const s = sim.getState()
   const maxTime = 120
   const dt = 0.016
-  while (s.elapsed < maxTime && s.status === 'playing'){
+  while (s.elapsed < maxTime && s.status === 'playing') {
     sim.step(dt)
     s.elapsed += dt
   }
   return s.elapsed
 }
 
-function evaluate(tuning, seeds){
+function evaluate(tuning, seeds) {
   let sum = 0
   const times = []
-  for (const seed of seeds){
+  for (const seed of seeds) {
     const t = runOnce(tuning, seed)
     sum += t
     times.push(t)
   }
   const avg = sum / seeds.length
-  times.sort((a,b)=>a-b)
-  const p90 = times[Math.floor(0.9*(times.length-1))]
+  times.sort((a, b) => a - b)
+  const p90 = times[Math.floor(0.9 * (times.length - 1))]
   const min = times[0]
-  const max = times[times.length-1]
+  const max = times[times.length - 1]
   return { avg, p90, min, max }
 }
 
-function rnd(arr){ return arr[Math.floor(Math.random()*arr.length)] }
+function rnd(arr) {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
 
-async function main(){
-  const epsList = [0.06, 0.08, 0.10, 0.12, 0.15, 0.18, 0.22]
-  const minDtList = [0.08, 0.10, 0.12, 0.15, 0.18, 0.22]
-  const cdList = [0.05, 0.08, 0.10, 0.12, 0.15, 0.20]
-  const chainList = [2,3,4,5,6]
+async function main() {
+  const epsList = [0.06, 0.08, 0.1, 0.12, 0.15, 0.18, 0.22]
+  const minDtList = [0.08, 0.1, 0.12, 0.15, 0.18, 0.22]
+  const cdList = [0.05, 0.08, 0.1, 0.12, 0.15, 0.2]
+  const chainList = [2, 3, 4, 5, 6]
   const noCloserList = [16, 24, 30, 36, 48, 60]
-  const depthList = [4,6,8]
-  const cordonRList = [80, 100, 120, 140, 160]
-  const cordonKList = [2,3,4,5]
+  const depthList = [4, 6, 8]
+  const reservedRadiusList = [80, 100, 120, 140, 160]
+  const cordonHoldList = [0.8, 1.0, 1.2, 1.5]
+  const cordonKList = [2, 3, 4, 5]
 
-  const numTrials = parseInt(process.env.TRIALS||'400',10)
-  const seeds = Array.from({length: parseInt(process.env.SEEDS||'10',10)}, (_,i)=>20250813+i)
+  const numTrials = parseInt(process.env.TRIALS || '400', 10)
+  const seeds = Array.from(
+    { length: parseInt(process.env.SEEDS || '10', 10) },
+    (_, i) => 20250813 + i,
+  )
 
   const tested = new Set()
   let top = [] // keep top 3 by avg
 
-  for (let i=0;i<numTrials;i++){
+  for (let i = 0; i < numTrials; i++) {
     const tuning = {
       eps: rnd(epsList),
       minDt: rnd(minDtList),
@@ -54,27 +60,38 @@ async function main(){
       maxChain: rnd(chainList),
       noCloserPx: rnd(noCloserList),
       planDepth: rnd(depthList),
-      cordonR: rnd(cordonRList),
+      reservedRadius: rnd(reservedRadiusList),
+      cordonHold: rnd(cordonHoldList),
       cordonK: rnd(cordonKList),
     }
     const key = JSON.stringify(tuning)
-    if (tested.has(key)){ i--; continue }
+    if (tested.has(key)) {
+      i--
+      continue
+    }
     tested.add(key)
 
     const res = evaluate(tuning, seeds)
     const entry = { tuning, ...res }
     top.push(entry)
-    top.sort((a,b)=>b.avg - a.avg)
-    if (top.length>3) top.length=3
+    top.sort((a, b) => b.avg - a.avg)
+    if (top.length > 3) top.length = 3
 
-    const status = `${(i+1)}/${numTrials} avg=${res.avg.toFixed(2)} p90=${res.p90.toFixed(2)} min=${res.min.toFixed(2)} max=${res.max.toFixed(2)} tun=${key}`
+    const status = `${i + 1}/${numTrials} avg=${res.avg.toFixed(2)} p90=${res.p90.toFixed(2)} min=${res.min.toFixed(2)} max=${res.max.toFixed(2)} tun=${key}`
     console.log(status)
   }
 
   console.log('\nTop 3 configs by avg:')
-  top.forEach((e,idx)=>{
-    console.log(`#${idx+1}`, e.tuning, `avg=${e.avg.toFixed(2)} p90=${e.p90.toFixed(2)} [${e.min.toFixed(2)}, ${e.max.toFixed(2)}]`)
+  top.forEach((e, idx) => {
+    console.log(
+      `#${idx + 1}`,
+      e.tuning,
+      `avg=${e.avg.toFixed(2)} p90=${e.p90.toFixed(2)} [${e.min.toFixed(2)}, ${e.max.toFixed(2)}]`,
+    )
   })
 }
 
-main().catch(err=>{console.error(err); process.exit(1)}) 
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/simulation.mjs
+++ b/simulation.mjs
@@ -1,258 +1,291 @@
 export function createSimulation(config) {
-    const state = {
-        width: 920,
-        height: 560,
-        nChairs: (config && config.nChairs) || 12,
-        chairRadius: (config && config.chairRadius) || 16,
-        mouseSpeed: (config && config.mouseSpeed) || 190,
-        teamSpeed: (config && config.teamSpeed) || 220,
-        seed: (config && config.seed) || 20250813,
-        running: true,
+  const state = {
+    width: 920,
+    height: 560,
+    nChairs: (config && config.nChairs) || 12,
+    chairRadius: (config && config.chairRadius) || 16,
+    mouseSpeed: (config && config.mouseSpeed) || 190,
+    teamSpeed: (config && config.teamSpeed) || 220,
+    seed: (config && config.seed) || 20250813,
+    running: true,
 
-        chairs: [],
-        players: [],
-        status: 'playing',
-        elapsed: 0,
-        lastTs: null,
-        dispatchCd: 0,
-        cordonActive: false,
-        cordonTargets: [],
-    };
+    chairs: [],
+    players: [],
+    status: 'playing',
+    elapsed: 0,
+    lastTs: null,
+    dispatchCd: 0,
+    reservedChairs: new Map(), // chairId -> release timestamp
+  }
 
-    const tuning = (config && config.tuning) || {}
-    // Planning parameters (configurable)
-    const EPS = tuning.eps ?? 0.12;            // relative margin per step
-    const MIN_DT = tuning.minDt ?? 0.12;       // absolute time margin per step (s)
-    const COOLDOWN = tuning.cooldown ?? 0.15;  // global cooldown
-    const PLAN_DEPTH = tuning.planDepth ?? 6;  // steps to simulate ahead
-    const NO_CLOSER_PX = tuning.noCloserPx ?? 24; // forbid creating new vacancy closer to mouse by more than this
-    const DEBUG = !!tuning.debug;
-    const MAX_CHAIN = tuning.maxChain ?? 3;    // how many defenders to chain per frame
-    const CORDON_R = tuning.cordonR ?? 120;    // distance to trigger cordon mode
-    const CORDON_K = tuning.cordonK ?? 3;      // chain length in cordon mode
-    const CORDON_HOLD = tuning.cordonHold ?? 1.2; // seconds to keep reservations after trigger
+  const tuning = (config && config.tuning) || {}
+  // Planning parameters (configurable)
+  const EPS = tuning.eps ?? 0.12 // relative margin per step
+  const MIN_DT = tuning.minDt ?? 0.12 // absolute time margin per step (s)
+  const COOLDOWN = tuning.cooldown ?? 0.15 // global cooldown
+  const PLAN_DEPTH = tuning.planDepth ?? 6 // steps to simulate ahead
+  const NO_CLOSER_PX = tuning.noCloserPx ?? 24 // forbid creating new vacancy closer to mouse by more than this
+  const DEBUG = !!tuning.debug
+  const MAX_CHAIN = tuning.maxChain ?? 3 // how many defenders to chain per frame
+  const RESERVED_RADIUS = tuning.reservedRadius ?? 120 // distance to trigger reservation
+  const CORDON_K = tuning.cordonK ?? 3 // number of chairs to reserve (including vacancy)
+  const CORDON_HOLD = tuning.cordonHold ?? 1.2 // seconds to keep reservations after trigger
 
-    const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y)
-    const sub = (a, b) => ({ x: a.x - b.x, y: a.y - b.y })
-    const add = (a, b) => ({ x: a.x + b.x, y: a.y + b.y })
-    const mul = (v, k) => ({ x: v.x * k, y: v.y * k })
-    const norm = (v) => { const d = Math.hypot(v.x, v.y) || 1; return { x: v.x / d, y: v.y / d } }
-    const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v))
-    function mulberry32(a){return function(){let t=a+=0x6D2B79F5;t=Math.imul(t^(t>>>15),t|1);t^=t+Math.imul(t^(t>>>7),t|61);return((t^(t>>>14))>>>0)/4294967296}}
+  const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y)
+  const sub = (a, b) => ({ x: a.x - b.x, y: a.y - b.y })
+  const add = (a, b) => ({ x: a.x + b.x, y: a.y + b.y })
+  const mul = (v, k) => ({ x: v.x * k, y: v.y * k })
+  const norm = (v) => {
+    const d = Math.hypot(v.x, v.y) || 1
+    return { x: v.x / d, y: v.y / d }
+  }
+  const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v))
+  function mulberry32(a) {
+    return function () {
+      let t = (a += 0x6d2b79f5)
+      t = Math.imul(t ^ (t >>> 15), t | 1)
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
 
-    function makeChairsDense(n,w,h,seed,chairRadius){
-        const rng=mulberry32(seed)
-        const safety = 12
-        const margin=chairRadius + safety
-        let minD=chairRadius*2.35
-        const chairs=[]
-        for(let i=0;i<n;i++){
-            let placed=false,attempts=0
-            while(!placed&&attempts<5000){
-                attempts++
-                const x = clamp(margin + rng()*(w-2*margin), margin, w-margin)
-                const y = clamp(margin + rng()*(h-2*margin), margin, h-margin)
-                const p = {x,y}
-                if(chairs.every(c=>dist(c.pos,p)>=minD)){
-                    chairs.push({id:i,pos:p}); placed=true
-                }
-                if(!placed && attempts%1000===0) minD*=0.96
-            }
-            if(!placed){
-                // ring fallback strictly inside margins
-                const r = Math.max(10, Math.min(w,h)/2 - margin)
-                const cx=w/2, cy=h/2
-                const ang=(i/Math.max(1,n))*Math.PI*2 + rng()*0.2
-                const px = clamp(cx + r*Math.cos(ang), margin, w-margin)
-                const py = clamp(cy + r*Math.sin(ang), margin, h-margin)
-                chairs.push({id:i,pos:{x:px,y:py}})
-            }
+  function makeChairsDense(n, w, h, seed, chairRadius) {
+    const rng = mulberry32(seed)
+    const safety = 12
+    const margin = chairRadius + safety
+    let minD = chairRadius * 2.35
+    const chairs = []
+    for (let i = 0; i < n; i++) {
+      let placed = false,
+        attempts = 0
+      while (!placed && attempts < 5000) {
+        attempts++
+        const x = clamp(margin + rng() * (w - 2 * margin), margin, w - margin)
+        const y = clamp(margin + rng() * (h - 2 * margin), margin, h - margin)
+        const p = { x, y }
+        if (chairs.every((c) => dist(c.pos, p) >= minD)) {
+          chairs.push({ id: i, pos: p })
+          placed = true
         }
-        // final clamp (safety)
-        for(const c of chairs){
-            c.pos.x = clamp(c.pos.x, margin, w-margin)
-            c.pos.y = clamp(c.pos.y, margin, h-margin)
-        }
-        return chairs
+        if (!placed && attempts % 1000 === 0) minD *= 0.96
+      }
+      if (!placed) {
+        // ring fallback strictly inside margins
+        const r = Math.max(10, Math.min(w, h) / 2 - margin)
+        const cx = w / 2,
+          cy = h / 2
+        const ang = (i / Math.max(1, n)) * Math.PI * 2 + rng() * 0.2
+        const px = clamp(cx + r * Math.cos(ang), margin, w - margin)
+        const py = clamp(cy + r * Math.sin(ang), margin, h - margin)
+        chairs.push({ id: i, pos: { x: px, y: py } })
+      }
+    }
+    // final clamp (safety)
+    for (const c of chairs) {
+      c.pos.x = clamp(c.pos.x, margin, w - margin)
+      c.pos.y = clamp(c.pos.y, margin, h - margin)
+    }
+    return chairs
+  }
+
+  function reset() {
+    state.chairs = makeChairsDense(
+      state.nChairs,
+      state.width,
+      state.height,
+      state.seed,
+      state.chairRadius,
+    )
+    const rng = mulberry32(state.seed + 42)
+    const emptyChairId = Math.floor(rng() * state.nChairs)
+    state.elapsed = 0
+    state.status = 'playing'
+    state.lastTs = null
+    state.dispatchCd = 0
+    state.reservedChairs.clear()
+    const team = []
+    let tIdx = 0
+    for (let i = 0; i < state.nChairs; i++) {
+      if (i === emptyChairId) continue
+      team.push({
+        id: `p-${tIdx++}`,
+        pos: { ...state.chairs[i].pos },
+        targetChairId: null,
+        sittingOn: i,
+      })
+    }
+    const emptyPos = state.chairs[emptyChairId].pos
+    const ang = rng() * Math.PI * 2
+    const far = Math.max(state.width, state.height) * 0.9 + 260
+    const safety = state.chairRadius + 12
+    const startInside = {
+      x: clamp(rng() * state.width, safety, state.width - safety),
+      y: clamp(rng() * state.height, safety, state.height - safety),
+    }
+    const mouse = {
+      id: 'mouse',
+      pos: startInside,
+      targetChairId: null,
+      sittingOn: null,
+    }
+    state.players = [mouse, ...team]
+  }
+
+  function step(dt) {
+    if (state.status !== 'playing') return
+    if (state.dispatchCd > 0)
+      state.dispatchCd = Math.max(0, state.dispatchCd - dt)
+
+    // clear expired reservations
+    for (const [cid, until] of state.reservedChairs.entries()) {
+      if (state.elapsed >= until) state.reservedChairs.delete(cid)
     }
 
-    function reset(){
-        state.chairs=makeChairsDense(state.nChairs,state.width,state.height,state.seed,state.chairRadius)
-        const rng=mulberry32(state.seed+42)
-        const emptyChairId=Math.floor(rng()*state.nChairs)
-        state.elapsed=0;state.status='playing';state.lastTs=null;state.dispatchCd=0
-        state.cordonActive = false
-        state.cordonTargets = []
-        state.cordonUntil = null // Clear hold
-        const team=[];let tIdx=0
-        for(let i=0;i<state.nChairs;i++){if(i===emptyChairId)continue;team.push({id:`p-${tIdx++}`,pos:{...state.chairs[i].pos},targetChairId:null,sittingOn:i})}
-        const emptyPos=state.chairs[emptyChairId].pos
-        const ang=rng()*Math.PI*2
-        const far=Math.max(state.width,state.height)*0.9+260
-        const safety = state.chairRadius + 12
-        const startInside = {
-            x: clamp(rng()*state.width, safety, state.width - safety),
-            y: clamp(rng()*state.height, safety, state.height - safety)
-        }
-        const mouse={id:'mouse',pos:startInside,targetChairId:null,sittingOn:null}
-        state.players=[mouse,...team]
+    const occupied = new Set(
+      state.players.filter((p) => p.sittingOn != null).map((p) => p.sittingOn),
+    )
+    const vacancies = state.chairs.filter((c) => !occupied.has(c.id))
+    if (vacancies.length === 0) {
+      state.status = 'team_won'
+      return
     }
 
-    function step(dt){
-        if(state.status!=='playing')return
-        if(state.dispatchCd>0)state.dispatchCd=Math.max(0,state.dispatchCd-dt)
+    const mouse = state.players.find((p) => p.id === 'mouse')
+    if (mouse.sittingOn != null) return
 
-        const occupied=new Set(state.players.filter(p=>p.sittingOn!=null).map(p=>p.sittingOn))
-        const vacancies=state.chairs.filter(c=>!occupied.has(c.id))
-        if(vacancies.length===0){state.status='team_won';return}
+    // choose vacancy with minimal mouse time now
+    let target = null
+    let tM = Infinity
+    for (const c of vacancies) {
+      const t = dist(mouse.pos, c.pos) / state.mouseSpeed
+      if (t < tM) {
+        tM = t
+        target = c
+      }
+    }
+    mouse.targetChairId = target.id
 
-        const mouse=state.players.find(p=>p.id==='mouse')
-        if(mouse.sittingOn!=null)return
+    const team = state.players.filter((p) => p.id !== 'mouse')
+    const lookup = new Map(state.chairs.map((c) => [c.id, c]))
 
-        // choose vacancy with minimal mouse time now
-        let target=null;let tM=Infinity
-        for(const c of vacancies){const t=dist(mouse.pos,c.pos)/state.mouseSpeed; if(t<tM){tM=t; target=c}}
-        mouse.targetChairId = target.id
-
-        const team=state.players.filter(p=>p.id!=='mouse')
-        const movers=team.filter(p=>p.targetChairId!=null)
-
-        // Always-on chain dispatch to prevent idle periods
-        if(movers.length===0){
-            let nextTarget = target.id
-            const chosenIds = new Set()
-            const near = dist(mouse.pos, state.chairs[nextTarget].pos) <= CORDON_R
-            const chainLen = near ? CORDON_K : MAX_CHAIN
-            const noCloserFactor = near ? 2 : 1
-
-            // reserved-seat cordon activation or hold
-            const holdActive = state.cordonUntil && state.elapsed < state.cordonUntil
-            const cordonActiveNow = near || holdActive
-            if (cordonActiveNow){
-                // helper to compute angularly distributed reserved seats around target
-                const computeReserved = (vacId)=>{
-                    const vacPos = state.chairs[vacId].pos
-                    const entries = state.chairs
-                        .filter(c=>c.id!==vacId)
-                        .map(c=>({id:c.id, d: dist(c.pos,vacPos), a: Math.atan2(c.pos.y-vacPos.y, c.pos.x-vacPos.x)}))
-                    entries.sort((a,b)=>a.d-b.d)
-                    const m = Math.min(entries.length, 12)
-                    const nearBy = entries.slice(0,m).sort((a,b)=>a.a-b.a)
-                    const guards = Math.max(0, CORDON_K-1)
-                    const picks = []
-                    if (guards>0){
-                        const stride = Math.max(1, Math.floor(nearBy.length/guards))
-                        for(let i=0;i<guards;i++){
-                            const idx = Math.min(i*stride, nearBy.length-1)
-                            picks.push(nearBy[idx].id)
-                        }
-                    }
-                    const unique = Array.from(new Set([vacId, ...picks]))
-                    return unique.slice(0, CORDON_K)
-                }
-
-                // refresh reservations if new target or not yet active
-                if (!state.cordonActive || !state.cordonTargets || !state.cordonTargets.includes(nextTarget)){
-                    state.cordonTargets = computeReserved(nextTarget)
-                    state.cordonActive = true
-                }
-                // extend hold while Mouse is near
-                if (near){
-                    state.cordonUntil = state.elapsed + CORDON_HOLD
-                }
-                // set reserved set for this frame
-                const reservedSet = new Set(state.cordonTargets)
-
-                // assign seated defenders to each reserved seat (including vacancy) if not already headed there
-                for (const tgtId of state.cordonTargets){
-                    const alreadyCovered = team.some(p=>p.sittingOn===tgtId || p.targetChairId===tgtId)
-                    if (alreadyCovered) continue
-                    let best=null,bestT=Infinity
-                    for(const p of team){
-                        if(p.sittingOn==null) continue
-                        if(chosenIds.has(p.id)) continue
-                        if(reservedSet.has(p.sittingOn)) continue // don't break reserved seats
-                        const t = dist(p.pos, state.chairs[tgtId].pos)/state.teamSpeed
-                        if(t<bestT){bestT=t; best=p}
-                    }
-                    if(!best) continue
-                    const tMcur = dist(mouse.pos, state.chairs[tgtId].pos)/state.mouseSpeed
-                    if(!(bestT < tMcur*(1-EPS) && (tMcur-bestT)>=MIN_DT)) continue
-                    if (tgtId===nextTarget){
-                        const prevSeat = best.sittingOn
-                        const dCur = dist(mouse.pos, state.chairs[nextTarget].pos)
-                        const dNew = dist(mouse.pos, state.chairs[prevSeat].pos)
-                        if (dNew + NO_CLOSER_PX*noCloserFactor < dCur) continue
-                    }
-                    best.targetChairId = tgtId
-                    best.sittingOn = null
-                    chosenIds.add(best.id)
-                }
-
-                // if mouse moved far and hold expired, clear cordon
-                if (!near && !(state.elapsed < state.cordonUntil)){
-                    state.cordonActive = false
-                    state.cordonTargets = []
-                }
-            }
-            // normal guarded chain when not covering via cordon this frame
-            if (chosenIds.size===0){
-                const reservedSet = new Set(state.cordonTargets||[])
-                for(let k=0;k<chainLen;k++){
-                    // pick fastest seated to nextTarget
-                    let best=null, bestT=Infinity
-                    for(const p of team){
-                        if(p.sittingOn==null) continue
-                        if(chosenIds.has(p.id)) continue
-                        if(reservedSet.has(p.sittingOn)) continue // do not break reserved seats
-                        const t = dist(p.pos, state.chairs[nextTarget].pos) / state.teamSpeed
-                        if(t<bestT){bestT=t; best=p}
-                    }
-                    if(!best) break
-                    // Constraints per hop
-                    const tMcur = dist(mouse.pos, state.chairs[nextTarget].pos)/state.mouseSpeed
-                    if(k===0 || k===1 || near){
-                        // require margin for first two hops
-                        if(!(bestT < tMcur*(1-EPS) && (tMcur-bestT)>=MIN_DT)){
-                            if(DEBUG)console.debug('skip hop',k,'insufficient margin')
-                            break
-                        }
-                    }
-                    const prevSeat = best.sittingOn
-                    // no-closer guard: new vacancy should not be much closer to mouse than current target
-                    const dCur = dist(mouse.pos, state.chairs[nextTarget].pos)
-                    const dNew = dist(mouse.pos, state.chairs[prevSeat].pos)
-                    if((k<=1 || near) && dNew + NO_CLOSER_PX*noCloserFactor < dCur){
-                        if(DEBUG)console.debug('skip hop',k,'new vacancy closer')
-                        break
-                    }
-                    best.targetChairId = nextTarget
-                    best.sittingOn = null
-                    chosenIds.add(best.id)
-                    nextTarget = prevSeat // chain to previous seat
-                }
-            }
-        }
-
-        // move
-        const lookup=new Map(state.chairs.map(c=>[c.id,c]))
-        for(const p of state.players){
-            if(p.targetChairId==null)continue
-            const pos=lookup.get(p.targetChairId).pos
-            const speed=p.id==='mouse'?state.mouseSpeed:state.teamSpeed
-            const stepLen=Math.min(speed*dt,dist(p.pos,pos))
-            p.pos=add(p.pos,mul(norm(sub(pos,p.pos)),stepLen))
-        }
-
-        // arrivals single-occupancy
-        const reach=state.chairRadius*0.5
-        const arrivals=[]
-        for(const p of state.players){if(p.targetChairId==null)continue;const pos=lookup.get(p.targetChairId).pos;const d=dist(p.pos,pos);if(d<=reach)arrivals.push({p,d,isMouse:p.id==='mouse'})}
-        arrivals.sort((a,b)=>a.d-b.d||(a.isMouse===b.isMouse?0:(a.isMouse?1:-1)))
-        const dyn=new Set(state.players.filter(p=>p.sittingOn!=null).map(p=>p.sittingOn))
-        for(const a of arrivals){const p=a.p;const cid=p.targetChairId;if(cid==null)continue;if(dyn.has(cid)){p.targetChairId=null;continue}if(p.id==='mouse'){p.sittingOn=cid;state.status='mouse_won';dyn.add(cid);break}else{p.sittingOn=cid;p.targetChairId=null;dyn.add(cid)}}
+    const near = dist(mouse.pos, lookup.get(target.id).pos) <= RESERVED_RADIUS
+    if (near) {
+      const tPos = lookup.get(target.id).pos
+      const entries = state.chairs.map((c) => ({
+        id: c.id,
+        d: dist(c.pos, tPos),
+      }))
+      entries.sort((a, b) => a.d - b.d)
+      const reserveIds = entries.slice(0, CORDON_K + 1).map((e) => e.id)
+      for (const cid of reserveIds) {
+        state.reservedChairs.set(cid, state.elapsed + CORDON_HOLD)
+      }
     }
 
-    reset()
-    return { step, getState:()=>state }
-} 
+    const reservedSet = new Set(state.reservedChairs.keys())
+
+    if (state.dispatchCd === 0) {
+      function plan(tgtId, depth, usedPlayers, usedSeats) {
+        if (usedSeats.has(tgtId)) return { margin: -Infinity, chain: [] }
+        const seatsNext = new Set(usedSeats)
+        seatsNext.add(tgtId)
+        const tMcur = dist(mouse.pos, lookup.get(tgtId).pos) / state.mouseSpeed
+        let best = { margin: -Infinity, chain: [] }
+        for (const p of team) {
+          if (p.sittingOn == null) continue
+          if (usedPlayers.has(p.id)) continue
+          if (reservedSet.has(p.sittingOn) && p.sittingOn !== tgtId) continue
+          const t = dist(p.pos, lookup.get(tgtId).pos) / state.teamSpeed
+          const margin = tMcur - t
+          if (!(margin >= MIN_DT && t <= tMcur * (1 - EPS))) continue
+          const prevSeat = p.sittingOn
+          const dCur = dist(mouse.pos, lookup.get(tgtId).pos)
+          const dNew = dist(mouse.pos, lookup.get(prevSeat).pos)
+          if (dNew + NO_CLOSER_PX < dCur) continue
+          let sub = { margin: Infinity, chain: [] }
+          if (depth > 1) {
+            const usedNext = new Set(usedPlayers)
+            usedNext.add(p.id)
+            sub = plan(prevSeat, depth - 1, usedNext, seatsNext)
+          }
+          const score = Math.min(margin, sub.margin)
+          if (score > best.margin) {
+            best = {
+              margin: score,
+              chain: [{ player: p, to: tgtId }, ...sub.chain],
+            }
+          }
+        }
+        return best
+      }
+
+      const seatsToCover =
+        reservedSet.size > 0 ? Array.from(reservedSet) : [target.id]
+      const used = new Set()
+      let dispatched = false
+      for (const cid of seatsToCover) {
+        const covered = team.some(
+          (p) => p.sittingOn === cid || p.targetChairId === cid,
+        )
+        if (covered) continue
+        const planRes = plan(cid, PLAN_DEPTH, used, new Set())
+        if (planRes.chain.length === 0) continue
+        for (const mv of planRes.chain.slice(0, MAX_CHAIN)) {
+          if (used.has(mv.player.id)) continue
+          mv.player.targetChairId = mv.to
+          mv.player.sittingOn = null
+          used.add(mv.player.id)
+          dispatched = true
+        }
+      }
+      if (dispatched) state.dispatchCd = COOLDOWN
+    }
+
+    // move
+    for (const p of state.players) {
+      if (p.targetChairId == null) continue
+      const pos = lookup.get(p.targetChairId).pos
+      const speed = p.id === 'mouse' ? state.mouseSpeed : state.teamSpeed
+      const stepLen = Math.min(speed * dt, dist(p.pos, pos))
+      p.pos = add(p.pos, mul(norm(sub(pos, p.pos)), stepLen))
+    }
+
+    // arrivals single-occupancy
+    const reach = state.chairRadius * 0.5
+    const arrivals = []
+    for (const p of state.players) {
+      if (p.targetChairId == null) continue
+      const pos = lookup.get(p.targetChairId).pos
+      const d = dist(p.pos, pos)
+      if (d <= reach) arrivals.push({ p, d, isMouse: p.id === 'mouse' })
+    }
+    arrivals.sort(
+      (a, b) => a.d - b.d || (a.isMouse === b.isMouse ? 0 : a.isMouse ? 1 : -1),
+    )
+    const dyn = new Set(
+      state.players.filter((p) => p.sittingOn != null).map((p) => p.sittingOn),
+    )
+    for (const a of arrivals) {
+      const p = a.p
+      const cid = p.targetChairId
+      if (cid == null) continue
+      if (dyn.has(cid)) {
+        p.targetChairId = null
+        continue
+      }
+      if (p.id === 'mouse') {
+        p.sittingOn = cid
+        state.status = 'mouse_won'
+        dyn.add(cid)
+        break
+      } else {
+        p.sittingOn = cid
+        p.targetChairId = null
+        dyn.add(cid)
+      }
+    }
+  }
+
+  reset()
+  return { step, getState: () => state }
+}

--- a/test.mjs
+++ b/test.mjs
@@ -1,57 +1,98 @@
 // Simulation Test Harness (ESM)
-import { createSimulation } from './simulation.mjs';
+import { createSimulation } from './simulation.mjs'
 
 function runTest(config) {
-    const sim = createSimulation(config);
-    const state = sim.getState();
+  const sim = createSimulation(config)
+  const state = sim.getState()
 
-    const maxTime = 120; // 2 minutes
-    const dt = 0.016; // 60 FPS
+  const maxTime = 120 // 2 minutes
+  const dt = 0.016 // 60 FPS
 
-    while (state.elapsed < maxTime && state.status === 'playing') {
-        sim.step(dt);
-        state.elapsed += dt;
-    }
+  while (state.elapsed < maxTime && state.status === 'playing') {
+    sim.step(dt)
+    state.elapsed += dt
+  }
 
-    return {
-        status: state.status,
-        time: state.elapsed,
-    };
+  return {
+    status: state.status,
+    time: state.elapsed,
+  }
 }
 
 function runBatchForTuning(tuning) {
-    const results = [];
-    for (let i = 0; i < 10; i++) {
-        const config = { seed: 20250813 + i, tuning };
-        const result = runTest(config);
-        results.push(result);
-    }
-    const avgTime = results.reduce((acc, r) => acc + r.time, 0) / results.length;
-    return avgTime;
+  const results = []
+  for (let i = 0; i < 10; i++) {
+    const config = { seed: 20250813 + i, tuning }
+    const result = runTest(config)
+    results.push(result)
+  }
+  const avgTime = results.reduce((acc, r) => acc + r.time, 0) / results.length
+  return avgTime
 }
 
 function sweep() {
-    console.log('Running tuning sweep...');
-    const candidates = [
-        { eps: 0.2, minDt: 0.18, cooldown: 0.10, maxChain: 6, noCloserPx: 36 },
-        { eps: 0.15, minDt: 0.15, cooldown: 0.12, maxChain: 5, noCloserPx: 30 },
-        { eps: 0.1, minDt: 0.10, cooldown: 0.08, maxChain: 8, noCloserPx: 40 },
-        { eps: 0.12, minDt: 0.12, cooldown: 0.05, maxChain: 10, noCloserPx: 24 },
-        { eps: 0.18, minDt: 0.16, cooldown: 0.10, maxChain: 7, noCloserPx: 32 },
-    ];
-    let best = null;
-    for (const t of candidates) {
-        const avg = runBatchForTuning(t);
-        console.log('tuning', t, 'avg', avg.toFixed(1));
-        if (!best || avg > best.avg) best = { t, avg };
-    }
-    console.log('\nBest tuning:', best.t, 'avg', best.avg.toFixed(1));
+  console.log('Running tuning sweep...')
+  const candidates = [
+    {
+      eps: 0.2,
+      minDt: 0.18,
+      cooldown: 0.1,
+      maxChain: 6,
+      noCloserPx: 36,
+      cordonHold: 1.2,
+      reservedRadius: 120,
+    },
+    {
+      eps: 0.15,
+      minDt: 0.15,
+      cooldown: 0.12,
+      maxChain: 5,
+      noCloserPx: 30,
+      cordonHold: 1.0,
+      reservedRadius: 110,
+    },
+    {
+      eps: 0.1,
+      minDt: 0.1,
+      cooldown: 0.08,
+      maxChain: 8,
+      noCloserPx: 40,
+      cordonHold: 1.5,
+      reservedRadius: 130,
+    },
+    {
+      eps: 0.12,
+      minDt: 0.12,
+      cooldown: 0.05,
+      maxChain: 10,
+      noCloserPx: 24,
+      cordonHold: 1.2,
+      reservedRadius: 140,
+    },
+    {
+      eps: 0.18,
+      minDt: 0.16,
+      cooldown: 0.1,
+      maxChain: 7,
+      noCloserPx: 32,
+      cordonHold: 1.0,
+      reservedRadius: 100,
+    },
+  ]
+  let best = null
+  for (const t of candidates) {
+    const avg = runBatchForTuning(t)
+    console.log('tuning', t, 'avg', avg.toFixed(1))
+    if (!best || avg > best.avg) best = { t, avg }
+  }
+  console.log('\nBest tuning:', best.t, 'avg', best.avg.toFixed(1))
 }
 
 if (process.env.SWEEP === '1') {
-    sweep();
+  sweep()
 } else {
-    console.log('Running batch simulation...');
-    const avg = runBatchForTuning({});
-    console.log('Default tuning avg', avg.toFixed(1));
+  console.log('Running batch simulation...')
+  const avg = runBatchForTuning({})
+  console.log('Default tuning avg', avg.toFixed(1))
 }
+


### PR DESCRIPTION
## Summary
- replace greedy chain swaps with recursive planner that searches defender sequences
- keep timed chair reservations and dispatch defenders only when cooldown allows
- maintain cross-browser compatibility for Safari on desktop and mobile

## Testing
- `npx prettier --write simulation.mjs test.mjs search.mjs STRATEGIES.md`
- `node test.mjs`
- `TRIALS=1 SEEDS=1 node search.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a238f2065483258b6d1a8ed47f5bd0